### PR TITLE
Add support for new Energy feature

### DIFF
--- a/p1reader.yaml
+++ b/p1reader.yaml
@@ -71,9 +71,15 @@ sensor:
   - name: "Cumulative Active Import"
     unit_of_measurement: kWh
     accuracy_decimals: 3
+    state_class: "measurement"
+    device_class: "energy"
+    last_reset_type: "never"
   - name: "Cumulative Active Export"
     unit_of_measurement: kWh
     accuracy_decimals: 3
+    state_class: "measurement"
+    device_class: "energy"
+    last_reset_type: "never"
   - name: "Cumulative Reactive Import"
     unit_of_measurement: kvarh
     accuracy_decimals: 3


### PR DESCRIPTION
The Energy panel, introduced in 2021.8, has some requirements for the sensor. This change sets the following for "Cumulative Active Import" and "Cumulative Active Export", allowing the sensor to be added to the Energy panel:
- `state_class` to `measurement`
- `device_class` to `energy`
- `last_reset_type` to `never`, which sets "epoch time".

Since Cumulative Active Export has the same unit I've made the same change there, but not sure if it is useful.

This should help with #12.