### PR TITLE
Use the new `total_increasing` state class

### DIFF
--- a/p1reader.yaml
+++ b/p1reader.yaml
@@ -71,15 +71,13 @@ sensor:
   - name: "Cumulative Active Import"
     unit_of_measurement: kWh
     accuracy_decimals: 3
-    state_class: "measurement"
+    state_class: "total_increasing"
     device_class: "energy"
-    last_reset_type: "never"
   - name: "Cumulative Active Export"
     unit_of_measurement: kWh
     accuracy_decimals: 3
-    state_class: "measurement"
+    state_class: "total_increasing"
     device_class: "energy"
-    last_reset_type: "never"
   - name: "Cumulative Reactive Import"
     unit_of_measurement: kvarh
     accuracy_decimals: 3


### PR DESCRIPTION
Remove the now deprecated `last_reset` attribute and change the `state_class` to the newly introduced `total_increasing` value as defined here: https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes