### PR TITLE
Update README.md, Aidon meter supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # esphome-p1reader
 ESPHome custom component for reading P1 data from electricity meters. Designed for Swedish meters that implements the specification defined in the [Swedish Energy Industry Recommendation For Customer Interfaces](https://www.energiforetagen.se/forlag/elnat/branschrekommendation-for-lokalt-kundgranssnitt-for-elmatare/) version 1.3 and above.
 
-Please note that the project currently doesn't support the Aidon meter from Tekniska Verken since that meter outputs the data in a binary format according to an earlier version (1.2) of the above mentioned recommendation.
-
 ## ESPHome version
 The current version in main is tested with ESPHome version `2022.9.0`. Make sure your ESPHome version is up to date if you experience compile problems.
 
@@ -13,6 +11,7 @@ The current version in main is tested with ESPHome version `2022.9.0`. Make sure
 * [S34U18 (Sanxing SX631)](https://www.vattenfalleldistribution.se/matarbyte/nya-elmataren/) / Vattenfall 
 * [KAIFA MA304H4E](https://reko.nackaenergi.se/elmatarbyte/) / Nacka Energi
 * [KAIFA CL109](https://www.oresundskraft.se/dags-for-matarbyte/) / Öresundskraft
+* [Aidon](https://www.tekniskaverken.se/kundservice/dinamatare/snart-far-du-nya-matare/) / Tekniska Verken
 
 *Note:* There's currently a bug in the E360 firmware, causing it to stop sending out data after a while. Check this comment for more info: https://github.com/psvanstrom/esphome-p1reader/issues/4#issuecomment-810794020
   


### PR DESCRIPTION
From the 16 jun Tekniska Verken pushed out 2.0 firmware to the Aidon meters. 
This custom component is now supported by the Aidon meters. 
I have tested it and it works.