### PR TITLE
Optimize performance (with reworked code structure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ESPHome custom component for reading P1 data from electricity meters. Designed for Swedish meters that implements the specification defined in the [Swedish Energy Industry Recommendation For Customer Interfaces](https://www.energiforetagen.se/forlag/elnat/branschrekommendation-for-lokalt-kundgranssnitt-for-elmatare/) version 1.3 and above.
 
 ## ESPHome version
-The current version in main is tested with ESPHome version `2022.12.1`. Make sure your ESPHome version is up to date if you experience compile problems.
+The current version in main is tested with ESPHome version `2023.8.1`. Make sure your ESPHome version is up to date if you experience compile problems.
 
 ## Verified meter hardware / supplier
 * [Sagemcom T211](https://www.ellevio.se/globalassets/content/el/elmatare-produktblad-b2c/ellevio_produktblad_fas3_t211_web2_.pdf) / Ellevio & Skånska Energi ([Info, port activation, etc.](https://www.ellevio.se/privat/om-din-el/elen-i-hemmet/forsta-din-elmatare/))
@@ -130,22 +130,14 @@ uart:
     id: uart_bus
     baud_rate: 115200
     rx_pin: D7
-    rx_buffer_size: 1700    
+    rx_buffer_size: 3072    
 ```
 
 [Sample configuration](./samples/slimmelezer.yaml), uses !secret for all site specific configuration, see below.
 
 ## Installation
-Clone the repository and create a companion `secrets.yaml` file with the following fields:
 
-If your electricity supplier is using Aidon 6442SE or Aidon 653X, you might also need to change the instantiation of the meter_sensor.
-As these meters are sometimes using the HDLC-protocol instead of ASCII. Open [p1reader.yaml](./p1reader.yaml)
-```c
-// Change
-auto meter_sensor = new P1Reader(id(uart_bus));
-// To
-auto meter_sensor = new P1ReaderHDLC(id(uart_bus));
-```
+Clone the repository and create a companion `secrets.yaml` file with the following fields:
 
 Create a companion `secrets.yaml` file with the following fields:
 ```
@@ -158,6 +150,8 @@ ota_password: <The OTA password>
 Check [the Native API Component chapter of the ESPHome documentation](https://esphome.io/components/api.html#configuration-variables) for more info on the encryption key, this page also let you easily generate an encryption key.
 
 Make sure to place the `secrets.yaml` file in the root path of the cloned project. The `fallback_password` and `ota_password` fields can be set to any password before doing the initial upload of the firmware.
+
+If your electricity supplier is using an Aidon 6442SE or Aidon 653X meter, they might still be using the HDLC protocol rather than the ASCII format for the meter data on the P1 port. Use the [Sample configuration for HDLC](./samples/p1reader_hdlc.yaml) to handle this setup. It configures a different input parser to handle the HDLC protocol.
 
 Prepare the microcontroller with ESPHome before you connect it to the circuit:
 - Install the `esphome` [command line tool](https://esphome.io/guides/getting_started_command_line.html)
@@ -200,11 +194,13 @@ You can check the logs by issuing `esphome p1reader.yaml logs` (or use the super
 [18:40:01][I][crc:275]: Telegram read. CRC: 7945 = 7945. PASS = YES
 ```
 
+Note that the default is the `INFO` loglevel since logging affects performance.
+
 The last row contains the CRC check. If you constantly get invalid CRC there might be something wrong with the serial communication.
 
 ## Technical documentation
 Specification overview:
-https://www.tekniskaverken.se/siteassets/tekniska-verken/elnat/aidonfd-rj12-han-interface-se-v13a.cleaned.pdf
+https://www.tekniskaverken.se/siteassets/tekniska-verken/elnat/elmatare-och-elanvandning/aidon-rj12-han-interface-v17a.pdf
 
 OBIS codes:
 https://tech.enectiva.cz/en/installation-instructions/others/obis-codes-meaning/

--- a/p1reader.h
+++ b/p1reader.h
@@ -5,6 +5,8 @@
 // History
 //  0.1.0 2020-11-05:   Initial release
 //  0.x.0 2023-04-18:   Added HDLC support
+//  0.2.0 2023-08-14:   Some optimizations when ESPHome started to complain about execution times
+//  0.3.0 2023-08-23:   Rework structure to merge above changes with HDLC stuff
 //
 // MIT License
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
@@ -20,506 +22,69 @@
 //-------------------------------------------------------------------------------------
 
 #include "esphome.h"
+#include "p1reader_base.h"
 
-#define BUF_SIZE 60
+class P1Reader : public P1ReaderBase {
 
-class ParsedMessage {
-  public:
-    double cumulativeActiveImport;
-    double cumulativeActiveExport;
-
-    double cumulativeReactiveImport;
-    double cumulativeReactiveExport;
-
-    double momentaryActiveImport;
-    double momentaryActiveExport;
-
-    double momentaryReactiveImport;
-    double momentaryReactiveExport;
-
-    double momentaryActiveImportL1;
-    double momentaryActiveExportL1;
-
-    double momentaryActiveImportL2;
-    double momentaryActiveExportL2;
-
-    double momentaryActiveImportL3;
-    double momentaryActiveExportL3;
-
-    double momentaryReactiveImportL1;
-    double momentaryReactiveExportL1;
-
-    double momentaryReactiveImportL2;
-    double momentaryReactiveExportL2;
-
-    double momentaryReactiveImportL3;
-    double momentaryReactiveExportL3;
-
-    double voltageL1;
-    double voltageL2;
-    double voltageL3;
-
-    double currentL1;
-    double currentL2;
-    double currentL3;
-
-    bool crcOk = false;
-};
-
-class P1Reader : public Component, public UARTDevice {
   const char* DELIMITERS = "()*:";
   const char* DATA_ID = "1-0";
 
-  protected:
-    char buffer[BUF_SIZE];
+public:    
+  P1Reader(UARTComponent *parent) : P1ReaderBase(parent) {}
 
-  public:
-    Sensor *cumulativeActiveImport = new Sensor();
-    Sensor *cumulativeActiveExport = new Sensor();
+protected:
+  void readP1Message() {
+    while (available()) {
+      int len = readBytesUntilAndIncluding('\n', _buffer + _bufferLen, BUF_SIZE-_bufferLen);
 
-    Sensor *cumulativeReactiveImport = new Sensor();
-    Sensor *cumulativeReactiveExport = new Sensor();
+      if (len > 0) {
+        _bufferLen += len;
+        bool lineComplete = _buffer[_bufferLen-1] == '\n';
+        
+        if (lineComplete) {
+          // if we've reached the CRC checksum, calculate last CRC and compare
+          if (_buffer[0] == '!') {
+            _parsedMessage.updateCrc16(_buffer[0]);
+            int crcFromMsg = (int) strtol(_buffer + 1, NULL, 16);
+            _parsedMessage.checkCrc(crcFromMsg);
+            ESP_LOGI("crc", "Telegram read. CRC: %04X = %04X. PASS = %s", 
+                      _parsedMessage.crc, crcFromMsg, _parsedMessage.crcOk ? "YES": "NO");
 
-    Sensor *momentaryActiveImport = new Sensor();
-    Sensor *momentaryActiveExport = new Sensor();
+          // otherwise pass the row through the CRC calculation
+          } else {
+            for (int i = 0; i < _bufferLen; i++) {
+              _parsedMessage.updateCrc16(_buffer[i]);
+            }
+          }
 
-    Sensor *momentaryReactiveImport = new Sensor();
-    Sensor *momentaryReactiveExport = new Sensor();
+          // Remove CR LF before logging and processing
+          _buffer[_bufferLen-1] = '\0';
+          if (_buffer[_bufferLen-2] == '\r')
+            _buffer[_bufferLen-2] = '\0';
+          ESP_LOGD("data", "Complete line [%s] received", _buffer);
 
-    Sensor *momentaryActiveImportL1 = new Sensor();
-    Sensor *momentaryActiveExportL1 = new Sensor();
+          // if this is a row containing information
+          if (strchr(_buffer, '(') != NULL) {
+            char* dataId = strtok(_buffer, DELIMITERS);
+            char* obisCode = strtok(NULL, DELIMITERS);
 
-    Sensor *momentaryActiveImportL2 = new Sensor();
-    Sensor *momentaryActiveExportL2 = new Sensor();
+            // ...and this row is a data row, then parse row
+            if (strncmp(DATA_ID, dataId, strlen(DATA_ID)) == 0) {
+              char* value = strtok(NULL, DELIMITERS);
+              char* unit = strtok(NULL, DELIMITERS);
+              _parsedMessage.parseRow(obisCode, value);
+            }
+          }
 
-    Sensor *momentaryActiveImportL3 = new Sensor();
-    Sensor *momentaryActiveExportL3 = new Sensor();
-
-    Sensor *momentaryReactiveImportL1 = new Sensor();
-    Sensor *momentaryReactiveExportL1 = new Sensor();
-
-    Sensor *momentaryReactiveImportL2 = new Sensor();
-    Sensor *momentaryReactiveExportL2 = new Sensor();
-
-    Sensor *momentaryReactiveImportL3 = new Sensor();
-    Sensor *momentaryReactiveExportL3 = new Sensor();
-
-    Sensor *voltageL1 = new Sensor();
-    Sensor *voltageL2 = new Sensor();
-    Sensor *voltageL3 = new Sensor();
-
-    Sensor *currentL1 = new Sensor();
-    Sensor *currentL2 = new Sensor();
-    Sensor *currentL3 = new Sensor();
-
-    P1Reader(UARTComponent *parent) : UARTDevice(parent) {}
-
-    void setup() override { }
-
-    void loop() override
-    {
-      readP1Message();
-    }
-
-  protected:
-    uint16_t crc16_update(uint16_t crc, uint8_t a) {
-      int i;
-      crc ^= a;
-      for (i = 0; i < 8; ++i) {
-        if (crc & 1) {
-            crc = (crc >> 1) ^ 0xA001;
+          // clean buffer for next line
+          memset(_buffer, 0, BUF_SIZE);
+          _bufferLen = 0;
         } else {
-            crc = (crc >> 1);
-        }
-      }
-      return crc;
-    }
-
-    void parseRow(ParsedMessage* parsed, char* obisCode, char* value) {
-      if (strncmp(obisCode, "1.8.0", 5) == 0) {
-        parsed->cumulativeActiveImport = atof(value);
-
-      } else if (strncmp(obisCode, "2.8.0", 5) == 0) {
-        parsed->cumulativeActiveExport = atof(value);
-
-      } else if (strncmp(obisCode, "3.8.0", 5) == 0) {
-        parsed->cumulativeReactiveImport = atof(value);
-
-      } else if (strncmp(obisCode, "4.8.0", 5) == 0) {
-        parsed->cumulativeReactiveExport = atof(value);
-
-      } else if (strncmp(obisCode, "1.7.0", 5) == 0) {
-        parsed->momentaryActiveImport = atof(value);
-
-      } else if (strncmp(obisCode, "2.7.0", 5) == 0) {
-        parsed->momentaryActiveExport = atof(value);
-
-      } else if (strncmp(obisCode, "3.7.0", 5) == 0) {
-        parsed->momentaryReactiveImport = atof(value);
-
-      } else if (strncmp(obisCode, "4.7.0", 5) == 0) {
-        parsed->momentaryReactiveExport = atof(value);
-
-      } else if (strncmp(obisCode, "21.7.0", 6) == 0) {
-        parsed->momentaryActiveImportL1 = atof(value);
-
-      } else if (strncmp(obisCode, "22.7.0", 6) == 0) {
-        parsed->momentaryActiveExportL1 = atof(value);
-
-      } else if (strncmp(obisCode, "41.7.0", 6) == 0) {
-        parsed->momentaryActiveImportL2 = atof(value);
-
-      } else if (strncmp(obisCode, "42.7.0", 6) == 0) {
-        parsed->momentaryActiveExportL2 = atof(value);
-
-      } else if (strncmp(obisCode, "61.7.0", 6) == 0) {
-        parsed->momentaryActiveImportL3 = atof(value);
-
-      } else if (strncmp(obisCode, "62.7.0", 6) == 0) {
-        parsed->momentaryActiveExportL3 = atof(value);
-
-      } else if (strncmp(obisCode, "23.7.0", 6) == 0) {
-        parsed->momentaryReactiveImportL1 = atof(value);
-
-      } else if (strncmp(obisCode, "24.7.0", 6) == 0) {
-        parsed->momentaryReactiveExportL1 = atof(value);
-
-      } else if (strncmp(obisCode, "43.7.0", 6) == 0) {
-        parsed->momentaryReactiveImportL2 = atof(value);
-
-      } else if (strncmp(obisCode, "44.7.0", 6) == 0) {
-        parsed->momentaryReactiveExportL2 = atof(value);
-
-      } else if (strncmp(obisCode, "63.7.0", 6) == 0) {
-        parsed->momentaryReactiveImportL3 = atof(value);
-
-      } else if (strncmp(obisCode, "64.7.0", 6) == 0) {
-        parsed->momentaryReactiveExportL3 = atof(value);
-
-      } else if (strncmp(obisCode, "32.7.0", 6) == 0) {
-        parsed->voltageL1 = atof(value);
-
-      } else if (strncmp(obisCode, "52.7.0", 6) == 0) {
-        parsed->voltageL2 = atof(value);
-
-      } else if (strncmp(obisCode, "72.7.0", 6) == 0) {
-        parsed->voltageL3 = atof(value);
-
-      } else if (strncmp(obisCode, "31.7.0", 6) == 0) {
-        parsed->currentL1 = atof(value);
-
-      } else if (strncmp(obisCode, "51.7.0", 6) == 0) {
-        parsed->currentL2 = atof(value);
-
-      } else if (strncmp(obisCode, "71.7.0", 6) == 0) {
-        parsed->currentL3 = atof(value);
-      }
-    }
-
-    void publishSensors(ParsedMessage* parsed) {
-      cumulativeActiveImport->publish_state(parsed->cumulativeActiveImport);
-      cumulativeActiveExport->publish_state(parsed->cumulativeActiveExport);
-
-      cumulativeReactiveImport->publish_state(parsed->cumulativeReactiveImport);
-      cumulativeReactiveExport->publish_state(parsed->cumulativeReactiveExport);
-
-      momentaryActiveImport->publish_state(parsed->momentaryActiveImport);
-      momentaryActiveExport->publish_state(parsed->momentaryActiveExport);
-
-      momentaryReactiveImport->publish_state(parsed->momentaryReactiveImport);
-      momentaryReactiveExport->publish_state(parsed->momentaryReactiveExport);
-
-      momentaryActiveImportL1->publish_state(parsed->momentaryActiveImportL1);
-      momentaryActiveExportL1->publish_state(parsed->momentaryActiveExportL1);
-
-      momentaryActiveImportL2->publish_state(parsed->momentaryActiveImportL2);
-      momentaryActiveExportL2->publish_state(parsed->momentaryActiveExportL2);
-
-      momentaryActiveImportL3->publish_state(parsed->momentaryActiveImportL3);
-      momentaryActiveExportL3->publish_state(parsed->momentaryActiveExportL3);
-
-      momentaryReactiveImportL1->publish_state(parsed->momentaryReactiveImportL1);
-      momentaryReactiveExportL1->publish_state(parsed->momentaryReactiveExportL1);
-
-      momentaryReactiveImportL2->publish_state(parsed->momentaryReactiveImportL2);
-      momentaryReactiveExportL2->publish_state(parsed->momentaryReactiveExportL2);
-
-      momentaryReactiveImportL3->publish_state(parsed->momentaryReactiveImportL3);
-      momentaryReactiveExportL3->publish_state(parsed->momentaryReactiveExportL3);
-
-      voltageL1->publish_state(parsed->voltageL1);
-      voltageL2->publish_state(parsed->voltageL2);
-      voltageL3->publish_state(parsed->voltageL3);
-
-      currentL1->publish_state(parsed->currentL1);
-      currentL2->publish_state(parsed->currentL2);
-      currentL3->publish_state(parsed->currentL3);
-    }
-
-  private:
-    void readP1Message() {
-      if (available()) {
-        uint16_t crc = 0x0000;
-        ParsedMessage parsed = ParsedMessage();
-        bool telegramEnded = false;
-
-        while (available()) {
-          int len = Serial.readBytesUntil('\n', buffer, BUF_SIZE);
-
-          if (len > 0) {
-          	ESP_LOGD("data", "%s", buffer);
-
-            // put newline back as it is required for CRC calculation
-            buffer[len] = '\n';
-            buffer[len + 1] = '\0';
-
-            // if we've reached the CRC checksum, calculate last CRC and compare
-            if (buffer[0] == '!') {
-              crc = crc16_update(crc, buffer[0]);
-              int crcFromMsg = (int) strtol(&buffer[1], NULL, 16);
-              parsed.crcOk = crc == crcFromMsg;
-              ESP_LOGI("crc", "Telegram read. CRC: %04X = %04X. PASS = %s", crc, crcFromMsg, parsed.crcOk ? "YES": "NO");
-              telegramEnded = true;
-
-            // otherwise pass the row through the CRC calculation
-            } else {
-              for (int i = 0; i < len + 1; i++) {
-                crc = crc16_update(crc, buffer[i]);
-              }
-            }
-
-            // if this is a row containing information
-            if (strchr(buffer, '(') != NULL) {
-              char* dataId = strtok(buffer, DELIMITERS);
-              char* obisCode = strtok(NULL, DELIMITERS);
-
-              // ...and this row is a data row, then parse row
-              if (strncmp(DATA_ID, dataId, strlen(DATA_ID)) == 0) {
-                char* value = strtok(NULL, DELIMITERS);
-                char* unit = strtok(NULL, DELIMITERS);
-                parseRow(&parsed, obisCode, value);
-              }
-            }
-          }
-          // clean buffer
-          memset(buffer, 0, BUF_SIZE - 1);
-        
-          if (!telegramEnded && !available()) {
-          	// wait for more data
-          	delay(40);
-          }
-        }
-
-        // if the CRC pass, publish sensor values
-        if (parsed.crcOk) {
-          publishSensors(&parsed);
+          ESP_LOGD("data", "Partial line [%s] received", _buffer);
+          // if we did not get a complete line, busywait for a single byte over uart
+          delayMicroseconds(_uSecondsPerByte);
         }
       }
     }
-
-    
-};
-
-class P1ReaderHDLC : public P1Reader {
-  const int8_t OUTSIDE_FRAME = 0;
-  const int8_t FOUND_FRAME = 1;
-
-
-  int8_t parseHDLCState = OUTSIDE_FRAME;
-
-  public:
-   P1ReaderHDLC(UARTComponent *parent) : P1Reader(parent) {}
-
-  void loop() override {
-    readHDLCMessage();
   }
-
-  private:
-    bool readHDLCStruct(ParsedMessage* parsed) {
-      if(Serial.readBytes(buffer, 3) != 3)
-        return false;
-
-      if(buffer[0] != 0x02) {
-        return false;
-      }
-
-      char obis[7];
-
-      uint8_t struct_len = buffer[1];
-      //ESP_LOGD("hdlc", "Struct length is %d", struct_len);
-
-      uint8_t tag = buffer[2];
-
-      if(tag != 0x09) {
-        ESP_LOGE("hdlc", "Unexpected tag %X in struct, bailing out", tag);
-        return false;
-      }
-      
-      uint8_t str_length = read();
-      if(Serial.readBytes(buffer, str_length) != str_length) {
-        ESP_LOGE("hdlc", "Unable to read %d bytes of OBIS code", str_length);
-        return false;
-      }
-      buffer[str_length] = 0; // Null-terminate
-      sprintf(obis, "%d.%d.%d", buffer[2], buffer[3], buffer[4]);
-
-      tag = read();
-
-      char value_buf[24];
-      bool is_signed = false;
-      uint32_t uvalue = 0;
-      int32_t value = 0;
-      if (tag == 0x09) {
-        str_length = read();
-        if(Serial.readBytes(buffer, str_length) != str_length) {
-          ESP_LOGE("hdlc", "Unable to read %d bytes of string", str_length);
-          return false;
-        }
-
-        buffer[str_length] = 0;
-        //ESP_LOGD("hdlc", "Read string length %d", str_length);
-      } else if(tag == 0x06) {
-        Serial.readBytes(buffer, 4);
-        //uvalue = buffer[0] | buffer[1] << 8 | buffer[2] << 16 | buffer[3] << 24;
-        uvalue = buffer[3] | buffer[2] << 8 | buffer[1] << 16 | buffer[0] << 24;
-        //ESP_LOGD("hdlc", "Value of uvalue is %u", uvalue);
-      } else if (tag == 0x10) {
-        Serial.readBytes(buffer, 2); 
-        //value = buffer[0] | buffer[1] << 8; // 
-        is_signed = true;
-        value = buffer[1] | buffer[0] << 8;
-        //ESP_LOGD("hdlc", "(Signed) Value of value is %d", value);
-      } else if (tag == 0x12) {
-        Serial.readBytes(buffer, 2); 
-        //uvalue = buffer[0] | buffer[1] << 8; // 
-        uvalue = buffer[1] | buffer[0] << 8;
-        //ESP_LOGD("hdlc", "(Unsigned) Value of uvalue is %u", uvalue);
-      } else {
-        ESP_LOGE("hdlc", "unknown tag %X", tag);
-      }
-
-      int8_t scaler;
-      uint8_t unit;
-      if(struct_len == 3) {
-        Serial.readBytes(buffer, 6);
-        scaler = buffer[3];
-        unit = buffer[5];
-        //ESP_LOGD("hdlc", "Scaler %u", scaler);
-        //ESP_LOGD("hdlc", "Unit %d", buffer[5]);
-
-      if(!is_signed)
-        value = uvalue;
-
-        double scaled_value = pow(10, scaler) * value;
-
-        // Volt and Ampere are the only two units where p1reader.yaml doesn't specify 
-        // we should report in 1/1000, all others should be divided.
-        if(unit != 33 && unit != 35)
-          scaled_value = scaled_value / 1000;
-        
-        snprintf(value_buf, 24, "%f", scaled_value);
-        parseRow(parsed, obis, value_buf);
-      }
-
-
-      
-
-      return true;
-    }
-
-    /* Reads messages formatted according to "Branschrekommendation v1.2", which
-       at the time of writing (20210207) is used by Tekniska Verken's Aidon 6442SE
-       meters. This is a binary format, with a HDLC Frame. 
-
-       This code is in no way a generic HDLC Frame parser, but it does the job
-       of decoding this particular data stream.
-    */
-    void readHDLCMessage()
-    {
-      if (available())
-      {
-        uint8_t data = 0;
-        uint16_t crc = 0x0000;
-        ParsedMessage parsed = ParsedMessage();
-
-        while (parseHDLCState == OUTSIDE_FRAME)
-        {
-          data = read();
-          if (data == 0x7e)
-          {
-            // ESP_LOGD("hdlc", "Found start of frame");
-            parseHDLCState = FOUND_FRAME;
-            break;
-
-            int8_t next = peek();
-
-            // ESP_LOGD("hdlc", "Next is %d", next);
-
-            if (next == 0x7e)
-            {
-              read(); // We were actually at the end flag, consume the start flag of the next frame.
-            } else if (next == -1) {
-              ESP_LOGE("hdlc", "No char available after flag, out of sync. Returning");
-              parseHDLCState = OUTSIDE_FRAME;
-              return;
-            }
-          }
-        }
-
-        if (parseHDLCState == FOUND_FRAME)
-        {
-          // Read various static HDLC Frame information we don't care about
-          int len = Serial.readBytes(buffer, 12);
-          if (len != 12) {
-            ESP_LOGE("hdlc", "Expected 12 bytes, got %d bytes - out of sync. Returning", len);
-            parseHDLCState = OUTSIDE_FRAME;
-            return;
-          }
-          // ESP_LOGD("hdlc", "Got %d HDLC bytes, now reading 4 Invoke ID And Priority bytes", len);          
-          len = Serial.readBytes(buffer, 4);
-          if (len != 4 || buffer[0] != 0x40 || buffer[1] != 0x00 || buffer[2] != 0x00 || buffer[3] != 0x00)
-          {
-            ESP_LOGE("hdlc", "Expected 0x40 0x00 0x00 0x00, got %X %X %X %X - out of sync, returning.", buffer[0], buffer[1], buffer[2], buffer[3]);
-            parseHDLCState = OUTSIDE_FRAME;
-            return;
-          }
-        }
-
-        data = read(); // Expect length of time field, usually 0
-        //ESP_LOGD("hdlc", "Length of datetime field is %d", data);
-        Serial.readBytes(buffer, data);
-
-        data = read();      
-        ESP_LOGD("hdlc", "Expect 0x01 (array tag), got 0x%02x", data);
-        if(data != 0x01) {
-          parseHDLCState = OUTSIDE_FRAME;
-          return;
-        }
-
-        uint8_t array_length = read();
-        ESP_LOGD("hdlc", "Array length is %d", array_length);
-
-        for(int i=0;i<array_length;i++) {
-          if(!readHDLCStruct(&parsed)) {
-            parseHDLCState = OUTSIDE_FRAME;
-            return;
-          }
-        }
-
-        publishSensors(&parsed);
-
-
-        while (true)
-        {
-          data = read();
-          //ESP_LOGD("hdlc", "Read char %02X", data);
-          if (data == 0x7e)
-          {
-            ESP_LOGD("hdlc", "Found end of frame");
-            parseHDLCState = OUTSIDE_FRAME;
-            return;
-          }
-        }
-      }
-    }
 };

--- a/p1reader.yaml
+++ b/p1reader.yaml
@@ -3,6 +3,8 @@ esphome:
   platform: ESP8266
   board: nodemcu
   includes:
+    - parsed_message.h
+    - p1reader_base.h
     - p1reader.h
 
 wifi:
@@ -18,8 +20,9 @@ captive_portal:
 
 # Enable logging
 logger:
-  level: DEBUG
-  baud_rate: 0 # disable logging over uart
+  level: INFO  # Logging costs performnce, swithc to DEBUG when needed
+  baud_rate: 0 # disable logging over uart (would use up a HW uart)
+  esp8266_store_log_strings_in_flash: false # Avoid flash wear and tear
   
 # Enable Home Assistant API
 api:
@@ -34,6 +37,7 @@ uart:
   tx_pin: TX
   rx_pin: RX
   baud_rate: 115200
+  rx_buffer_size: 3072    # Buffer size controls polling frequency
 
 # If your electricity meter is an Aidon, which use the older
 # Branschstandard (1.2) where the data is HDLC-formatted

--- a/p1reader_base.h
+++ b/p1reader_base.h
@@ -1,0 +1,210 @@
+//-------------------------------------------------------------------------------------
+// ESPHome P1 Electricity Meter custom sensor
+// Copyright 2020 Pär Svanström
+// 
+// History
+//  0.1.0 2020-11-05:   Initial release
+//  0.x.0 2023-04-18:   Added HDLC support
+//  0.2.0 2023-08-14:   Some optimizations when ESPHome started to complain about execution times
+//  0.3.0 2023-08-23:   Rework structure to merge above changes with HDLC stuff
+//
+// MIT License
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+// IN THE SOFTWARE.
+//-------------------------------------------------------------------------------------
+
+#ifndef P1READER_BASE_H
+#define P1READER_BASE_H
+
+#include "esphome.h"
+#include "parsed_message.h"
+
+#define BUF_SIZE 60
+
+class P1ReaderBase : public PollingComponent, public UARTDevice {
+  int _pollingIntervalMs;
+  int _pollingIntervalLog = 30;
+
+  protected:
+    ParsedMessage _parsedMessage = ParsedMessage();
+    char _buffer[BUF_SIZE];
+    uint8_t _bufferLen;
+    int _uSecondsPerByte;
+
+  public:
+    Sensor *cumulativeActiveImport = new Sensor();
+    Sensor *cumulativeActiveExport = new Sensor();
+
+    Sensor *cumulativeReactiveImport = new Sensor();
+    Sensor *cumulativeReactiveExport = new Sensor();
+
+    Sensor *momentaryActiveImport = new Sensor();
+    Sensor *momentaryActiveExport = new Sensor();
+
+    Sensor *momentaryReactiveImport = new Sensor();
+    Sensor *momentaryReactiveExport = new Sensor();
+
+    Sensor *momentaryActiveImportL1 = new Sensor();
+    Sensor *momentaryActiveExportL1 = new Sensor();
+
+    Sensor *momentaryActiveImportL2 = new Sensor();
+    Sensor *momentaryActiveExportL2 = new Sensor();
+
+    Sensor *momentaryActiveImportL3 = new Sensor();
+    Sensor *momentaryActiveExportL3 = new Sensor();
+
+    Sensor *momentaryReactiveImportL1 = new Sensor();
+    Sensor *momentaryReactiveExportL1 = new Sensor();
+
+    Sensor *momentaryReactiveImportL2 = new Sensor();
+    Sensor *momentaryReactiveExportL2 = new Sensor();
+
+    Sensor *momentaryReactiveImportL3 = new Sensor();
+    Sensor *momentaryReactiveExportL3 = new Sensor();
+
+    Sensor *voltageL1 = new Sensor();
+    Sensor *voltageL2 = new Sensor();
+    Sensor *voltageL3 = new Sensor();
+
+    Sensor *currentL1 = new Sensor();
+    Sensor *currentL2 = new Sensor();
+    Sensor *currentL3 = new Sensor();
+
+    P1ReaderBase(UARTComponent *parent) : PollingComponent(), UARTDevice(parent) {
+      // Calculate pollingInterval for Component given our uart buffer size and the rest
+      size_t rxBufferSize = parent->get_rx_buffer_size();
+      uint8_t bits = parent->get_data_bits() + parent->get_stop_bits() + (parent->get_parity() != UART_CONFIG_PARITY_NONE ? 1 : 0) + 1;
+      float secondsPerByte = (float)bits * (1.0f / (float) parent->get_baud_rate());
+
+      ESP_LOGD("setup", "secondsPerByte calculated as: %f s", secondsPerByte);
+      
+      _uSecondsPerByte = (int) (secondsPerByte * 1000000.0f);
+      // Keep a margin of 20%
+      _pollingIntervalMs = (int)((float)rxBufferSize * secondsPerByte * 800.0f);
+      
+      set_update_interval(_pollingIntervalMs);
+    }
+
+    float get_setup_priority() const override { return esphome::setup_priority::LATE; }
+
+    void setup() override {
+      // Start with a clean buffer
+      memset(_buffer, 0, BUF_SIZE);
+      _bufferLen = 0;
+      
+      _parsedMessage.initNewTelegram();
+    }
+
+    void update() override {
+      // Defer setup logging to here (and repeat a few times) as OTA logs do not pick up initial logs otherwise
+      if (_pollingIntervalLog >= 0) {
+        if (_pollingIntervalMs < 20) {
+          ESP_LOGE("setup", "Polling interval is too low: %d ms (rx_buffer_size %d, uSecondsPerByte %d)", 
+                   _pollingIntervalMs, parent_->get_rx_buffer_size(), _uSecondsPerByte);
+        } else if (_pollingIntervalMs < 100) {
+          ESP_LOGW("setup", "Polling interval is low: %d ms (rx_buffer_size %d, uSecondsPerByte %d)", 
+                   _pollingIntervalMs, parent_->get_rx_buffer_size(), _uSecondsPerByte);
+        } else {
+          ESP_LOGI("setup", "Polling interval calculated as: %d ms (rx_buffer_size %d, uSecondsPerByte %d)", 
+                   _pollingIntervalMs, parent_->get_rx_buffer_size(), _uSecondsPerByte);
+        }
+        
+        _pollingIntervalLog--;
+      }
+
+      // Deliver a parsed and crc ok message in the calls _after_ actually reading it so we 
+      // split the work over more scheduler slices since publish_state is slow (and logging is slow
+      // so set log level INFO to avoid all teh debug logging slowing things down)
+      if (_parsedMessage.telegramComplete) {
+        publishSensors(&_parsedMessage);
+
+        if (!_parsedMessage.telegramComplete) {
+          readP1Message();
+        }
+      } else {
+        readP1Message();
+      }
+    }
+
+  protected:
+
+    void publishSensors(ParsedMessage* parsedMessage) {
+      if (parsedMessage->crcOk && parsedMessage->telegramComplete)
+      {
+        if (parsedMessage->sendBatchOne) {
+          cumulativeActiveImport->publish_state(parsedMessage->cumulativeActiveImport);
+          cumulativeActiveExport->publish_state(parsedMessage->cumulativeActiveExport);
+  
+          momentaryActiveImport->publish_state(parsedMessage->momentaryActiveImport);
+          momentaryActiveExport->publish_state(parsedMessage->momentaryActiveExport);
+  
+          momentaryActiveImportL1->publish_state(parsedMessage->momentaryActiveImportL1);
+          momentaryActiveExportL1->publish_state(parsedMessage->momentaryActiveExportL1);
+  
+          momentaryActiveImportL2->publish_state(parsedMessage->momentaryActiveImportL2);
+          momentaryActiveExportL2->publish_state(parsedMessage->momentaryActiveExportL2);
+  
+          momentaryActiveImportL3->publish_state(parsedMessage->momentaryActiveImportL3);
+          momentaryActiveExportL3->publish_state(parsedMessage->momentaryActiveExportL3);
+  
+          voltageL1->publish_state(parsedMessage->voltageL1);
+          voltageL2->publish_state(parsedMessage->voltageL2);
+          voltageL3->publish_state(parsedMessage->voltageL3);
+        
+          parsedMessage->sendBatchOne = false;
+          
+          ESP_LOGD("publish", "Sensors published (part one). CRC: %04X", parsedMessage->crc);
+        } else {
+          currentL1->publish_state(parsedMessage->currentL1);
+          currentL2->publish_state(parsedMessage->currentL2);
+          currentL3->publish_state(parsedMessage->currentL3);
+  
+          cumulativeReactiveImport->publish_state(parsedMessage->cumulativeReactiveImport);
+          cumulativeReactiveExport->publish_state(parsedMessage->cumulativeReactiveExport);
+  
+          momentaryReactiveImport->publish_state(parsedMessage->momentaryReactiveImport);
+          momentaryReactiveExport->publish_state(parsedMessage->momentaryReactiveExport);
+  
+          momentaryReactiveImportL1->publish_state(parsedMessage->momentaryReactiveImportL1);
+          momentaryReactiveExportL1->publish_state(parsedMessage->momentaryReactiveExportL1);
+  
+          momentaryReactiveImportL2->publish_state(parsedMessage->momentaryReactiveImportL2);
+          momentaryReactiveExportL2->publish_state(parsedMessage->momentaryReactiveExportL2);
+  
+          momentaryReactiveImportL3->publish_state(parsedMessage->momentaryReactiveImportL3);
+          momentaryReactiveExportL3->publish_state(parsedMessage->momentaryReactiveExportL3);
+  
+          ESP_LOGI("publish", "Sensors published (complete). CRC: %04X", parsedMessage->crc);
+  
+          parsedMessage->initNewTelegram();
+        }
+      } else if (!parsedMessage->crcOk && parsedMessage->telegramComplete) {
+        parsedMessage->initNewTelegram();
+      }
+    }
+    
+    size_t readBytesUntilAndIncluding(char terminator, char *buffer, size_t length) {
+      size_t index = 0;
+      while (index < length) {
+        uint8_t c;
+        bool hasData = read_byte(&c);
+        if (!hasData) break;
+        *buffer++ = (char)c;
+        index++;
+        if (c == terminator) break;
+      }
+      return index; // return number of characters, not including null terminator
+    }    
+
+    virtual void readP1Message() = 0;
+};
+
+#endif

--- a/p1reader_hdlc.h
+++ b/p1reader_hdlc.h
@@ -1,0 +1,215 @@
+//-------------------------------------------------------------------------------------
+// ESPHome P1 Electricity Meter custom sensor
+// Copyright 2020 Pär Svanström
+// 
+// History
+//  0.1.0 2020-11-05:   Initial release
+//  0.x.0 2023-04-18:   Added HDLC support
+//  0.2.0 2023-08-14:   Some optimizations when ESPHome started to complain about execution times
+//  0.3.0 2023-08-23:   Rework structure to merge above changes with HDLC stuff
+//
+// MIT License
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+// IN THE SOFTWARE.
+//-------------------------------------------------------------------------------------
+
+#include "esphome.h"
+#include "p1reader_base.h"
+
+class P1ReaderHDLC : public P1ReaderBase {
+  const int8_t OUTSIDE_FRAME = 0;
+  const int8_t FOUND_FRAME = 1;
+
+  int8_t parseHDLCState = OUTSIDE_FRAME;
+
+  public:
+    P1ReaderHDLC(UARTComponent *parent) : P1ReaderBase(parent) {}
+
+  private:
+    bool readHDLCStruct() {
+      if (!read_array((uint8_t*)_buffer, 3))
+        return false;
+
+      if (_buffer[0] != 0x02) {
+        return false;
+      }
+
+      char obis[7];
+
+      uint8_t struct_len = _buffer[1];
+      //ESP_LOGD("hdlc", "Struct length is %d", struct_len);
+
+      uint8_t tag = _buffer[2];
+
+      if (tag != 0x09) {
+        ESP_LOGE("hdlc", "Unexpected tag %X in struct, bailing out", tag);
+        return false;
+      }
+      
+      uint8_t str_length = read();
+      if (read_array((uint8_t*)_buffer, str_length) != str_length) {
+        ESP_LOGE("hdlc", "Unable to read %d bytes of OBIS code", str_length);
+        return false;
+      }
+      _buffer[str_length] = 0; // Null-terminate
+      sprintf(obis, "%d.%d.%d", _buffer[2], _buffer[3], _buffer[4]);
+
+      tag = read();
+
+      bool is_signed = false;
+      uint32_t uvalue = 0;
+      int32_t value = 0;
+      if (tag == 0x09) {
+        str_length = read();
+        if (read_array((uint8_t*)_buffer, str_length) != str_length) {
+          ESP_LOGE("hdlc", "Unable to read %d bytes of string", str_length);
+          return false;
+        }
+
+        _buffer[str_length] = 0;
+        //ESP_LOGD("hdlc", "Read string length %d", str_length);
+      } else if (tag == 0x06) {
+        read_array((uint8_t*)_buffer, 4);
+        //uvalue = _buffer[0] | _buffer[1] << 8 | _buffer[2] << 16 | _buffer[3] << 24;
+        uvalue = _buffer[3] | _buffer[2] << 8 | _buffer[1] << 16 | _buffer[0] << 24;
+        //ESP_LOGD("hdlc", "Value of uvalue is %u", uvalue);
+      } else if (tag == 0x10) {
+        read_array((uint8_t*)_buffer, 2); 
+        //value = _buffer[0] | _buffer[1] << 8; // 
+        is_signed = true;
+        value = _buffer[1] | _buffer[0] << 8;
+        //ESP_LOGD("hdlc", "(Signed) Value of value is %d", value);
+      } else if (tag == 0x12) {
+        read_array((uint8_t*)_buffer, 2); 
+        //uvalue = _buffer[0] | _buffer[1] << 8; // 
+        uvalue = _buffer[1] | _buffer[0] << 8;
+        //ESP_LOGD("hdlc", "(Unsigned) Value of uvalue is %u", uvalue);
+      } else {
+        ESP_LOGE("hdlc", "unknown tag %X", tag);
+      }
+
+      int8_t scaler;
+      uint8_t unit;
+      if (struct_len == 3) {
+        read_array((uint8_t*)_buffer, 6);
+        scaler = _buffer[3];
+        unit = _buffer[5];
+        //ESP_LOGD("hdlc", "Scaler %u", scaler);
+        //ESP_LOGD("hdlc", "Unit %d", _buffer[5]);
+
+      if (!is_signed)
+        value = uvalue;
+
+        double scaled_value = pow(10, scaler) * value;
+
+        // Volt and Ampere are the only two units where p1reader.yaml doesn't specify 
+        // we should report in 1/1000, all others should be divided.
+        if(unit != 33 && unit != 35)
+          scaled_value = scaled_value / 1000;
+        
+        _parsedMessage.parseRow(obis, scaled_value);
+      }
+
+      return true;
+    }
+
+    /* Reads messages formatted according to "Branschrekommendation v1.2", which
+       at the time of writing (20210207) is used by Tekniska Verken's Aidon 6442SE
+       meters. This is a binary format, with a HDLC Frame. 
+
+       This code is in no way a generic HDLC Frame parser, but it does the job
+       of decoding this particular data stream.
+    */
+    void readP1Message() {
+      if (available())
+      {
+        uint8_t data = 0;
+        uint16_t crc = 0x0000;
+
+        while (parseHDLCState == OUTSIDE_FRAME)
+        {
+          data = read();
+          if (data == 0x7e)
+          {
+            // ESP_LOGD("hdlc", "Found start of frame");
+            parseHDLCState = FOUND_FRAME;
+            break;
+
+            int8_t next = peek();
+
+            // ESP_LOGD("hdlc", "Next is %d", next);
+
+            if (next == 0x7e)
+            {
+              read(); // We were actually at the end flag, consume the start flag of the next frame.
+            } else if (next == -1) {
+              ESP_LOGE("hdlc", "No char available after flag, out of sync. Returning");
+              parseHDLCState = OUTSIDE_FRAME;
+              return;
+            }
+          }
+        }
+
+        if (parseHDLCState == FOUND_FRAME)
+        {
+          // Read various static HDLC Frame information we don't care about
+          int len = read_array((uint8_t*)_buffer, 12);
+          if (len != 12) {
+            ESP_LOGE("hdlc", "Expected 12 bytes, got %d bytes - out of sync. Returning", len);
+            parseHDLCState = OUTSIDE_FRAME;
+            return;
+          }
+          // ESP_LOGD("hdlc", "Got %d HDLC bytes, now reading 4 Invoke ID And Priority bytes", len);          
+          len = read_array((uint8_t*)_buffer, 4);
+          if (len != 4 || _buffer[0] != 0x40 || _buffer[1] != 0x00 || _buffer[2] != 0x00 || _buffer[3] != 0x00)
+          {
+            ESP_LOGE("hdlc", "Expected 0x40 0x00 0x00 0x00, got %X %X %X %X - out of sync, returning.", _buffer[0], _buffer[1], _buffer[2], _buffer[3]);
+            parseHDLCState = OUTSIDE_FRAME;
+            return;
+          }
+        }
+
+        data = read(); // Expect length of time field, usually 0
+        //ESP_LOGD("hdlc", "Length of datetime field is %d", data);
+        read_array((uint8_t*)_buffer, data);
+
+        data = read();      
+        ESP_LOGD("hdlc", "Expect 0x01 (array tag), got 0x%02x", data);
+        if (data != 0x01) {
+          parseHDLCState = OUTSIDE_FRAME;
+          return;
+        }
+
+        uint8_t array_length = read();
+        ESP_LOGD("hdlc", "Array length is %d", array_length);
+
+        for (int i=0;i<array_length;i++) {
+          if(!readHDLCStruct()) {
+            parseHDLCState = OUTSIDE_FRAME;
+            return;
+          }
+        }
+
+        _parsedMessage.crcOk = _parsedMessage.telegramComplete = true;
+
+        while ((data = read()) != -1)
+        {
+          //ESP_LOGD("hdlc", "Read char %02X", data);
+          if (data == 0x7e)
+          {
+            ESP_LOGD("hdlc", "Found end of frame");
+            parseHDLCState = OUTSIDE_FRAME;
+            return;
+          }
+        }
+      }
+    }
+};

--- a/parsed_message.h
+++ b/parsed_message.h
@@ -1,0 +1,207 @@
+#ifndef PARSED_MESSAGE_H
+#define PARSED_MESSAGE_H
+
+class ParsedMessage {
+  public:
+    double cumulativeActiveImport;
+    double cumulativeActiveExport;
+
+    double cumulativeReactiveImport;
+    double cumulativeReactiveExport;
+
+    double momentaryActiveImport;
+    double momentaryActiveExport;
+
+    double momentaryReactiveImport;
+    double momentaryReactiveExport;
+
+    double momentaryActiveImportL1;
+    double momentaryActiveExportL1;
+
+    double momentaryActiveImportL2;
+    double momentaryActiveExportL2;
+
+    double momentaryActiveImportL3;
+    double momentaryActiveExportL3;
+
+    double momentaryReactiveImportL1;
+    double momentaryReactiveExportL1;
+
+    double momentaryReactiveImportL2;
+    double momentaryReactiveExportL2;
+
+    double momentaryReactiveImportL3;
+    double momentaryReactiveExportL3;
+
+    double voltageL1;
+    double voltageL2;
+    double voltageL3;
+
+    double currentL1;
+    double currentL2;
+    double currentL3;
+  
+    uint16_t crc;
+    bool telegramComplete;
+    bool crcOk;
+    bool sendBatchOne;
+
+    void parseRow(const char* obisCode, const char* value) {
+        double obisValue = simpleatof(value);
+
+        parseRow(obisCode, obisValue);
+    }
+
+    void parseRow(const char* obisCode, double obisValue) {
+      int obisCodeLen = strnlen(obisCode, 7);
+      
+      if (obisCode[obisCodeLen-1] == '0' &&
+          obisCode[obisCodeLen-2] == '.' &&
+          obisCode[obisCodeLen-4] == '.') {
+            
+        switch (obisCodeLen) {
+          case 5: switch(obisCode[obisCodeLen-3]) {
+                    case '7': switch (obisCode[0]) {
+                                case '1': momentaryActiveImport = obisValue;
+                                          break;
+                                case '2': momentaryActiveExport = obisValue;
+                                          break;
+                                case '3': momentaryReactiveImport = obisValue;
+                                          break;
+                                case '4': momentaryReactiveExport = obisValue;
+                                          break;
+                                default: break;
+                              }
+                              break;
+                    case '8': switch (obisCode[0]) {
+                                case '1': cumulativeActiveImport = obisValue;
+                                          break;
+                                case '2': cumulativeActiveExport = obisValue;
+                                          break;
+                                case '3': cumulativeReactiveImport = obisValue;
+                                          break;
+                                case '4': cumulativeReactiveExport = obisValue;
+                                          break;
+                                default: break;
+                              }
+                              break;
+                    default: break;
+                  }
+                  break;
+          case 6: if (obisCode[obisCodeLen-3] == '7') {
+                    switch(obisCode[1]) {
+                      case '1': switch (obisCode[0]) {
+                                  case '2': momentaryActiveImportL1 = obisValue;
+                                            break;
+                                  case '3': currentL1 = obisValue;
+                                            break;
+                                  case '4': momentaryActiveImportL2 = obisValue;
+                                            break;
+                                  case '5': currentL2 = obisValue;
+                                            break;
+                                  case '6': momentaryActiveImportL3 = obisValue;
+                                            break;
+                                  case '7': currentL3 = obisValue;
+                                            break;
+                                  default: break;
+                                }
+                                break;
+                      case '2': switch (obisCode[0]) {
+                                  case '2': momentaryActiveExportL1 = obisValue;
+                                            break;
+                                  case '3': voltageL1 = obisValue;
+                                            break;
+                                  case '4': momentaryActiveExportL2 = obisValue;
+                                            break;
+                                  case '5': voltageL2 = obisValue;
+                                            break;
+                                  case '6': momentaryActiveExportL3 = obisValue;
+                                            break;
+                                  case '7': voltageL3 = obisValue;
+                                            break;
+                                  default: break;
+                                }
+                                break;
+                      case '3': switch (obisCode[0]) {
+                                  case '2': momentaryReactiveImportL1 = obisValue;
+                                            break;
+                                  case '4': momentaryReactiveImportL2 = obisValue;
+                                            break;
+                                  case '6': momentaryReactiveImportL3 = obisValue;
+                                            break;
+                                  default: break;
+                                }
+                                break;
+                      case '4': switch (obisCode[0]) {
+                                  case '2': momentaryReactiveExportL1 = obisValue;
+                                            break;
+                                  case '4': momentaryReactiveExportL2 = obisValue;
+                                            break;
+                                  case '6': momentaryReactiveExportL3 = obisValue;
+                                            break;
+                                  default: break;
+                                }
+                                break;
+                      default: break;
+                    }
+                  }
+                  break;
+          default: break;
+        }
+      }
+    }
+
+    // Limitations: 
+    //   Numbers larger than 2G will fail (but spec only goes to 99999999.999 so ok)
+    //   And numbers have no more than 3 decimals in the spec.
+    //   spec == Swedish spec for H1
+    double simpleatof(const char* value) {
+      double decFactors[10] = {10.0, 100.0, 1000.0, 100000.0,
+                               1000000.0, 10000000.0, 100000000.0,
+                               1000000000.0, 10000000000.0,
+                               100000000000.0};
+      int idx = 0;
+      int intPart = 0;
+      while (value[idx] != '.')
+      {
+        intPart = intPart*10 + (value[idx]-'0');
+        idx++;
+      }
+
+      int len = strlen(value), startIdx = ++idx;
+      int decPart = 0;
+      while (idx < len)
+      {
+        decPart = decPart*10 + (value[idx]-'0');
+        idx++;
+      }
+
+      return intPart + decPart/decFactors[len-startIdx-1];
+    }
+
+    void initNewTelegram() {
+      crc = 0x0000;
+      telegramComplete = false;
+      crcOk = false;
+      sendBatchOne = true;
+    }
+
+    void updateCrc16(uint8_t a) {
+      int i;
+      crc ^= a;
+      for (i = 0; i < 8; ++i) {
+        if (crc & 1) {
+            crc = (crc >> 1) ^ 0xA001;
+        } else {
+            crc = (crc >> 1);
+        }
+      }
+    }
+    
+    void checkCrc(uint16_t crcFromMessage) {
+      crcOk = crc == crcFromMessage;
+      telegramComplete = true;
+    }
+};
+
+#endif

--- a/samples/p1reader_hdlc.yaml
+++ b/samples/p1reader_hdlc.yaml
@@ -1,81 +1,48 @@
-substitutions:
-  device_name: slimmelezer
-  device_description: "P1 module to read smart meter"
-     
 esphome:
-  name: ${device_name}
-  comment: "${device_description}"
+  name: esp-p1readerhdlc
   platform: ESP8266
-  esp8266_restore_from_flash: true
-  board: d1_mini
-  name_add_mac_suffix: false
-  project:
-    name: zuidwijk.slimmelezer
-    version: "1.0"
+  board: nodemcu
   includes:
     - parsed_message.h
     - p1reader_base.h
-    - p1reader.h
-  
+    - p1reader_hdlc.h
+
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
 
-  fast_connect: True
-
   # Enable fallback hotspot (captive portal) in case wifi connection fails
-  # ap:
-  #   ssid: ${device_name}
-  #   ap_timeout: 15s
-  #   password: !secret fallback_ap_password
-
-  reboot_timeout: 5min
-  domain: .local
+  ap:
+    ssid: "esp-p1readerhdlc"
+    password: !secret fallback_password
 
 captive_portal:
 
 # Enable logging
-# baud_rate: 0, stops the logger using UART logging so it does not use the hardware one that might be needed for the
-# actual device to work properly
-# And avoid some wear on the flash for device longevity
 logger:
-  baud_rate: 0
-  esp8266_store_log_strings_in_flash: false
-  level: INFO
+  level: INFO  # Logging costs performnce, switch to DEBUG when needed only
+  baud_rate: 0 # disable logging over uart (would use up a HW uart)
+  esp8266_store_log_strings_in_flash: false # Avoid flash wear and tear
   
 # Enable Home Assistant API
 api:
-          
+  encryption:
+    key: !secret encryption_key
+    
 ota:
   password: !secret ota_password
 
-web_server:
-  port: 80
- 
 uart:
   id: uart_bus
+  tx_pin: TX
+  rx_pin: RX
   baud_rate: 115200
-  rx_pin: D7
-  rx_buffer_size: 3072
-
-binary_sensor:
-  - platform: status
-    name: "SlimmeLezer - Status"  
+  rx_buffer_size: 3072    # Buffer size controls polling frequency
 
 sensor:
-- platform: uptime
-  name: "SlimmeLezer - Uptime"
-  update_interval: 60s
-  icon: mdi:clock-outline
-
-- platform: wifi_signal
-  name: "SlimmeLezer - Wi-Fi Signal"
-  update_interval: 60s
-  icon: mdi:wifi
-
 - platform: custom
   lambda: |-
-    auto meter_sensor = new P1Reader(id(uart_bus));
+    auto meter_sensor = new P1ReaderHDLC(id(uart_bus));
     App.register_component(meter_sensor);
     return {
       meter_sensor->cumulativeActiveImport,
@@ -216,20 +183,3 @@ sensor:
     accuracy_decimals: 3
     state_class: "measurement"
     device_class: "current"
- 
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "SlimmeLezer - IP Address"
-    ssid:
-      name: "SlimmeLezer - Wi-Fi SSID"
-    bssid:
-      name: "SlimmeLezer - Wi-Fi BSSID"
-    mac_address:
-      name: "SlimmeLezer - Wi-Fi MAC Address"
-    dns_address:
-      name: "SlimmeLezer - DNS Address"
-
-  - platform: version
-    name: "SlimmeLezer - ESPHome Version"
-    hide_timestamp: false


### PR DESCRIPTION
This quickly got out of hand but began when ESPHome started delivering warnings like these:

[W][component:204]: Component <unknown> took a long time for an operation (0.06 s).
[W][component:205]: Components should block for at most 20-30ms.

Irritating so how to fix?

Well initial, but wrong, assumption was that using loop and just continuously polling was the culprit.
Actually it was the time to do each iteration of loop it was complaining about...

Having moved to a polling component with a calculated polling interval based on the rx buffer size I realized this when the warnings were identical. But the change should have the benefit of not busy-waiting the cpu and using less power.

So what does cause this then? 

One thing is (excessive) logging, this is fixed by having only essential logging as Info, all the rest as debug and then setting loglevel INFO in the config

Another thing is publish_state that apparently also takes time, I think noone at Nabu Case intended a sensor to have this many values... but, here it was possible to move the publish into a separate "time slice" from the fetch and parse stage and then split it into two parts to get the time for each slice down to < 30ms.

Even so there still were frequent complaints for the read part so what to optimize further?

atof could be changed into a simpler variant since the fixed format nature of the P1 data is not so complex. atof time now take about a third of the regular implementation.

Even so there still were less frequent complaints so what to optimize further?

Change the obis parser from O(n) to O(1) (where n is the number of possible obis values) so the overall parsing time is O(n) rather than O(n^2) where n is the number of actual obis values in the message.

Now we are down to almost no warnings about time used...

So here I went to do a PR and realized that "Oh, no!" (https://www.youtube.com/watch?v=sP7njpTd06I) the code has changed...

Skip the whole thing or?

But with some more code rearranging, here we are.

Note that I have _NOT_ tested the HDLC version since I only have the newer standard here (using my Slimmelezer). I did switch it away from the mix of EspHome and Arduino serial access. There is still a compile warning in the HDLC version around the use of sprintf and limited but in reality ok buffer for obis codes. And the HDLC version does not use atof at all...