### PR TITLE
readBytesUntil from configured UARTDevice instead of Serial

### DIFF
--- a/p1reader.h
+++ b/p1reader.h
@@ -257,6 +257,32 @@ class P1Reader : public Component, public UARTDevice {
     }
 
   private:
+    int timedRead() {
+      const unsigned long _startMillis = millis();
+      int c;
+      do {
+        if (available()) {
+            c = read();
+            if (c >= 0) return c;
+        }
+        else {
+            delay(1);
+        }
+      } while(millis() - _startMillis < 1000); // default timeout is 1000ms
+      return -1;  // indicates timeout
+    }
+
+    int readBytesUntil(const char terminator, char *data, const size_t len) {
+        size_t count = 0;
+        while (count < len) {
+            int c = timedRead();
+            if (c < 0 || terminator == (char) c) break;
+            data[count] = (char) c;
+            count++;
+        }
+        return count;
+    }
+
     void readP1Message() {
       if (available()) {
         uint16_t crc = 0x0000;
@@ -264,7 +290,7 @@ class P1Reader : public Component, public UARTDevice {
         bool telegramEnded = false;
 
         while (available()) {
-          int len = Serial.readBytesUntil('\n', buffer, BUF_SIZE);
+          int len = readBytesUntil('\n', buffer, BUF_SIZE-1);
 
           if (len > 0) {
           	ESP_LOGD("data", "%s", buffer);


### PR DESCRIPTION
Reading lines from the P1 port using
```
          int len = Serial.readBytesUntil('\n', buffer, BUF_SIZE);
```
appears to be hardcoded to reading from `RX` instead of the configured `rx_pin`
```
uart:
  id: uart_bus
  rx_pin:
    number: GPIO6
    inverted: true
  baud_rate: 115200
```

Please note I haven't tested this change on a dev board, so cannot claim it is generic - but I think it is.