### PR TITLE
Avoid interval 0ms at startup

### DIFF
--- a/esphome-components/p1reader/p1reader.h
+++ b/esphome-components/p1reader/p1reader.h
@@ -36,7 +36,10 @@ namespace esphome
         class P1Reader : public PollingComponent, public uart::UARTDevice
         {
         public:
-            P1Reader(uart::UARTComponent *parent): PollingComponent(), uart::UARTDevice(parent)
+            // Start with an interval > 0ms, we will update it later anyway
+            // ESPHome 2026.4.0 actually makes 0 possible, but breaks everything else
+            // WO in ESPHome2026.4.1
+            P1Reader(uart::UARTComponent *parent): PollingComponent(10), uart::UARTDevice(parent)
             {}
 
             void setup() override;


### PR DESCRIPTION
ESPHome 2026.4.0 is now so optimized that it actually handles an interval of 0ms, that though gives no time to anything else in the ESPHome firmware so it gets stuck and the watchdog fires.

A workaround is also in 2026.4.1.

https://github.com/esphome/esphome/pull/15799