### PR TITLE
Add optional repeat_to_tx mode to echo meter data out the TX pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It handles both the **ASCII** telegram format (most meters) and the binary **HDL
 - [Verifying the output](#verifying-the-output)
 - [Controlling the update frequency](#controlling-the-update-frequency)
 - [Running on other boards](#running-on-other-boards)
+- [Sharing the port with a second device (repeater)](#sharing-the-port-with-a-second-device-repeater)
 - [Technical documentation](#technical-documentation)
 
 ## Verified meters
@@ -257,6 +258,20 @@ Marcel Zuidwijk's [Slimmelezer+](https://www.zuidwijk.com/product/slimmelezer-pl
    ```
 
 See the [Slimmelezer sample configuration](./samples/slimmelezer.yaml), which uses `!secret` for all site-specific configuration (see [Installation](#installation)).
+
+## Sharing the port with a second device (repeater)
+
+The component can act as an active repeater: with `repeat_to_tx: true`, every byte it reads from the meter is echoed straight out the UART **TX** pin, so a second P1 device (e.g. a Tibber Pulse) can share a single P1 port without an active splitter.
+
+```yaml
+p1reader:
+  - id: p1reader_esp
+    uart_id: uart_bus
+    repeat_to_tx: true
+```
+
+> [!WARNING]
+> This requires additional hardware and is **off by default**. The TX pin needs the same treatment as RX — the ESP's 3.3 V output must be **inverted and level-shifted to a 5 V open-collector signal** (a second transistor stage, mirroring the RX circuit); wiring TX directly to the second device will not work reliably. Make sure your `uart:` also defines a `tx_pin`. Note too that the P1 port's ~250 mA supply may not be enough to power both the ESP and a second device — the second device may need its own supply. The hardware side is your responsibility; the option only handles echoing the data stream.
 
 ## Technical documentation
 

--- a/components/p1reader/__init__.py
+++ b/components/p1reader/__init__.py
@@ -15,6 +15,7 @@ AUTO_LOAD = ["sensor"]
 CONF_P1READER_ID = "p1reader_id"
 CONF_BUFFER_SIZE = "buffer_size"
 CONF_PROTOCOL = "protocol"
+CONF_REPEAT_TO_TX = "repeat_to_tx"
 
 p1reader_ns = cg.esphome_ns.namespace("esphome::p1_reader")
 P1Reader = p1reader_ns.class_("P1Reader", cg.PollingComponent, uart.UARTDevice)
@@ -25,6 +26,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(P1Reader),
             cv.Optional(CONF_BUFFER_SIZE, default=60): cv.positive_not_null_int,
             cv.Optional(CONF_PROTOCOL, default="ascii"): cv.one_of("ascii", "hdlc", lower=True),
+            cv.Optional(CONF_REPEAT_TO_TX, default=False): cv.boolean,
         }
     ).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA),
     cv.only_with_arduino,
@@ -37,6 +39,7 @@ async def to_code(config):
     await cg.register_component(var, config)
 
     cg.add(var.set_protocol_type(config[CONF_PROTOCOL]))
+    cg.add(var.set_repeat_to_tx(config[CONF_REPEAT_TO_TX]))
     if config[CONF_PROTOCOL] == "ascii":
         cg.add_define("BUF_SIZE", config[CONF_BUFFER_SIZE])
     else:

--- a/components/p1reader/p1reader.cpp
+++ b/components/p1reader/p1reader.cpp
@@ -298,6 +298,18 @@ namespace esphome
             }
         }
 
+        bool P1Reader::readByteRepeat(uint8_t *data)
+        {
+            bool hasData = read_byte(data);
+            // Act as an active repeater: echo every byte received from the meter
+            // straight out the TX pin so a second P1 device can share the port.
+            if (hasData && _repeatToTx)
+            {
+                write_byte(*data);
+            }
+            return hasData;
+        }
+
         size_t P1Reader::readBytesUntilAndIncluding(char terminator, char *buffer, size_t length)
         {
             size_t index = 0;
@@ -305,7 +317,7 @@ namespace esphome
             while (index < length)
             {
                 uint8_t c;
-                bool hasData = read_byte(&c);
+                bool hasData = readByteRepeat(&c);
                 if (!hasData)
                 {
                     break;
@@ -349,13 +361,13 @@ namespace esphome
 
                 while (_parseHDLCState == OUTSIDE_FRAME)
                 {
-                    bool hasData = read_byte(&data);
+                    bool hasData = readByteRepeat(&data);
                     if (hasData && data == 0x7e)
                     {
                         uint8_t wait = 10;
                         while (!hasData && wait > 0)
                         {
-                            hasData = read_byte(&data);
+                            hasData = readByteRepeat(&data);
                             if (!hasData)
                             {
                                 delayMicroseconds(_uSecondsPerByte);
@@ -390,7 +402,7 @@ namespace esphome
 
                 while (_parseHDLCState == READING_FRAME)
                 {
-                    bool hasData = read_byte(&data);
+                    bool hasData = readByteRepeat(&data);
                     if (hasData)
                     {
                         _buffer[_bufferLen++] = data;

--- a/components/p1reader/p1reader.h
+++ b/components/p1reader/p1reader.h
@@ -50,6 +50,10 @@ namespace esphome
             // Shared
             int _pollingIntervalMs;
 
+            // When true, every byte read from the meter is echoed out the TX pin
+            // so a second P1 device can share the port (see set_repeat_to_tx).
+            bool _repeatToTx{false};
+
             ParsedMessage _parsedMessage = ParsedMessage();
             char _buffer[BUF_SIZE];
             uint16_t _bufferLen;
@@ -101,6 +105,10 @@ namespace esphome
 
             size_t readBytesUntilAndIncluding(char terminator, char *buffer, size_t length);
 
+            // Reads a single byte from the meter, echoing it out the TX pin when
+            // repeater mode is enabled. Returns false when no byte was available.
+            bool readByteRepeat(uint8_t *data);
+
             // HLDC
             const int8_t OUTSIDE_FRAME = 0;
             const int8_t READING_FRAME = 2;
@@ -126,6 +134,11 @@ namespace esphome
                     readP1Message = &esphome::p1_reader::P1Reader::readP1MessageHDLC;
 
                 ESP_LOGI("setup", "Protocol is %s", protocol.c_str());
+            }
+
+            void set_repeat_to_tx(bool enabled)
+            {
+                _repeatToTx = enabled;
             }
 
             void set_sensor_cumulative_active_import(sensor::Sensor *sensor)


### PR DESCRIPTION
dds an optional active-repeater mode so a second P1 device (e.g. a Tibber Pulse) can share a single P1 port without an active splitter. Implements #65.